### PR TITLE
fix: properly export built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@staratlas/stv",
   "version": "1.0.0",
   "description": "STV vote algorithm code package for the Star Atlas DAO",
+  "main": "dist/dist.cjs.js",
   "scripts": {
     "build": "vite build",
     "watch": "vite build -w --emptyOutDir=false",
@@ -34,6 +35,10 @@
     "vite": "^5.4.1",
     "vite-plugin-dts": "^4.0.3"
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "exports": {
     ".": {
       "types": "./dist/dist.d.ts",


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to improve the build configuration and package distribution.

Build configuration and package distribution improvements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R5): Added the `main` field to specify the entry point for the package.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R38-R41): Added the `files` field to include the `dist` and `src` directories in the package distribution.