### PR TITLE
feat: another fix for publishing on npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@staratlas/stv",
   "version": "1.0.0",
   "description": "STV vote algorithm code package for the Star Atlas DAO",
-  "main": "dist/dist.cjs.js",
+  "main": "dist/index.cjs.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "vite build",
     "watch": "vite build -w --emptyOutDir=false",
@@ -36,14 +38,14 @@
     "vite-plugin-dts": "^4.0.3"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "exports": {
     ".": {
-      "types": "./dist/dist.d.ts",
-      "import": "./dist/dist.es.js",
-      "require": "./dist/dist.cjs.js"
-    }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./*": "./dist/*"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "noEmit": true,
     "sourceMap": true,
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "outDir": "./dist"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["jest.config.ts"],
+  "include": ["jest.config.ts", "src/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/vite.utils.mts
+++ b/vite.utils.mts
@@ -4,7 +4,13 @@ import dtsPlugin from 'vite-plugin-dts';
 
 export const libConfig = (entryName: string): UserConfig =>
   defineConfig({
-    plugins: [dtsPlugin({ rollupTypes: true })],
+    plugins: [
+      dtsPlugin({
+        rollupTypes: true,
+        outDir: 'dist', // Ensure declaration files are output to the dist folder
+        entryRoot: 'src', // Use src as the root for type declarations
+      }),
+    ],
     build: {
       rollupOptions: {
         plugins: [autoExternal()],
@@ -13,7 +19,7 @@ export const libConfig = (entryName: string): UserConfig =>
       lib: {
         entry: entryName,
         formats: ['es', 'cjs'],
-        fileName: (format) => `dist.${format}.js`,
+        fileName: (format) => `index.${format}.js`,
       },
       target: 'esnext',
       sourcemap: true,


### PR DESCRIPTION
This pull request includes several changes to the configuration files for the Star Atlas DAO's STV vote algorithm code package. The changes primarily focus on updating file paths, ensuring proper output directories, and refining the build process.

Configuration and build process updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R7): Updated the `main`, `source`, and `types` fields to point to the new `index` files, and modified the `files` and `exports` fields to reflect the new structure. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L39-R49)
* [`tsconfig.base.json`](diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL19-R20): Added the `outDir` property to ensure that compiled files are output to the `dist` directory.
* [`vite.utils.mts`](diffhunk://#diff-b2b4c1637cb5e9e5c560b266dfb37629fce3b1bf35e59136b341503c190e747aL7-R13): Updated the `dtsPlugin` configuration to ensure declaration files are output to the `dist` folder and use `src` as the root for type declarations. Also changed the `fileName` format to use `index` instead of `dist`. [[1]](diffhunk://#diff-b2b4c1637cb5e9e5c560b266dfb37629fce3b1bf35e59136b341503c190e747aL7-R13) [[2]](diffhunk://#diff-b2b4c1637cb5e9e5c560b266dfb37629fce3b1bf35e59136b341503c190e747aL16-R22)